### PR TITLE
Fixed `no-color` flag issues #29

### DIFF
--- a/cmd/html_report.go
+++ b/cmd/html_report.go
@@ -4,363 +4,374 @@
 package cmd
 
 import (
-    "errors"
-    "fmt"
-    "github.com/pb33f/openapi-changes/git"
-    htmlReport "github.com/pb33f/openapi-changes/html-report"
-    "github.com/pb33f/openapi-changes/model"
-    "github.com/pterm/pterm"
-    "github.com/spf13/cobra"
-    "github.com/twinj/uuid"
-    "net/url"
-    "os"
-    "path/filepath"
-    "strings"
-    "time"
+	"errors"
+	"fmt"
+	"github.com/pb33f/openapi-changes/git"
+	htmlReport "github.com/pb33f/openapi-changes/html-report"
+	"github.com/pb33f/openapi-changes/model"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+	"github.com/twinj/uuid"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 )
 
 func GetHTMLReportCommand() *cobra.Command {
 
-    cmd := &cobra.Command{
-        SilenceUsage:  false,
-        SilenceErrors: false,
-        Use:           "html-report",
-        Short:         "Generate the sexiest, most interactive diffing experience you have ever seen.",
-        Long: "Generate a ready to go, super sexy, and highly interactive HTML report that " +
-            "you can explore and review in your browser",
-        Example: "openapi-changes html-report /path/to/git/repo path/to/file/in/repo/openapi.yaml",
-        RunE: func(cmd *cobra.Command, args []string) error {
+	cmd := &cobra.Command{
+		SilenceUsage:  false,
+		SilenceErrors: false,
+		Use:           "html-report",
+		Short:         "Generate the sexiest, most interactive diffing experience you have ever seen.",
+		Long: "Generate a ready to go, super sexy, and highly interactive HTML report that " +
+			"you can explore and review in your browser",
+		Example: "openapi-changes html-report /path/to/git/repo path/to/file/in/repo/openapi.yaml",
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-            updateChan := make(chan *model.ProgressUpdate)
-            errorChan := make(chan model.ProgressError)
-            doneChan := make(chan bool)
-            failed := false
+			updateChan := make(chan *model.ProgressUpdate)
+			errorChan := make(chan model.ProgressError)
+			doneChan := make(chan bool)
+			failed := false
 
-            noColorFlag, _ := cmd.Flags().GetBool("no-color")
-            cdnFlag, _ := cmd.Flags().GetBool("use-cdn")
-            latestFlag, _ := cmd.Flags().GetBool("top")
-            limitFlag, _ := cmd.Flags().GetInt("limit")
+			noColorFlag, _ := cmd.Flags().GetBool("no-color")
+			cdnFlag, _ := cmd.Flags().GetBool("use-cdn")
+			latestFlag, _ := cmd.Flags().GetBool("top")
+			limitFlag, _ := cmd.Flags().GetInt("limit")
 
-            if noColorFlag {
-                pterm.DisableStyling()
-                pterm.DisableColor()
-            }
+			if noColorFlag {
+				pterm.DisableStyling()
+				pterm.DisableColor()
+			}
 
-            PrintBanner()
+			PrintBanner()
 
-            // if there are no args, print out how to use the console.
-            if len(args) == 0 {
-                PrintHowToUse("html-report")
-                return nil
-            }
+			// if there are no args, print out how to use the console.
+			if len(args) == 0 {
+				PrintHowToUse("html-report")
+				return nil
+			}
 
-            listenForUpdates := func(updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) {
-                spinner, _ := pterm.DefaultSpinner.Start("starting work.")
-                for {
-                    select {
-                    case update, ok := <-updateChan:
-                        if ok {
-                            spinner.UpdateText(update.Message)
-                            if update.Warning {
-                                pterm.Warning.Println(update.Message)
-                            }
-                        } else {
-                            if !failed {
-                                spinner.Info("all done, html report is ready.")
-                            } else {
-                                spinner.Fail("failed to complete. sorry!")
-                            }
-                            doneChan <- true
-                            return
-                        }
-                    case err := <-errorChan:
-                        //failed = true
-                        if err.Fatal {
-                            spinner.Fail(fmt.Sprintf("Stopped: %s", err.Message))
-                            doneChan <- true
-                            return
-                        } else {
-                            pterm.Warning.Println(err.Message)
-                        }
-                    }
-                }
-            }
+			listenForUpdates := func(updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) {
+				var spinner *pterm.SpinnerPrinter
+				if !noColorFlag {
+					spinner, _ = pterm.DefaultSpinner.Start("starting work.")
+				}
+				for {
+					select {
+					case update, ok := <-updateChan:
+						if ok {
+							if !noColorFlag {
+								spinner.UpdateText(update.Message)
+							}
+							if update.Warning {
+								pterm.Warning.Println(update.Message)
+							}
+						} else {
+							if !failed {
+								if !noColorFlag {
+									spinner.Info("all done, html report is ready.")
+								}
+							} else {
+								if !noColorFlag {
+									spinner.Fail("failed to complete. sorry!")
+								}
+							}
+							doneChan <- true
+							return
+						}
+					case err := <-errorChan:
+						//failed = true
+						if err.Fatal {
+							if !noColorFlag {
+								spinner.Fail(fmt.Sprintf("Stopped: %s", err.Message))
+							}
+							doneChan <- true
+							return
+						} else {
+							pterm.Warning.Println(err.Message)
+						}
+					}
+				}
+			}
 
-            // check for two args (left and right)
-            if len(args) < 2 {
+			// check for two args (left and right)
+			if len(args) < 2 {
 
-                // check if arg is an url (like a github url)
-                url, err := url.Parse(args[0])
-                if err == nil {
+				// check if arg is an url (like a github url)
+				url, err := url.Parse(args[0])
+				if err == nil {
 
-                    if url.Host == "github.com" {
-                        go listenForUpdates(updateChan, errorChan)
+					if url.Host == "github.com" {
+						go listenForUpdates(updateChan, errorChan)
 
-                        user, repo, filePath, err := ExtractGithubDetailsFromURL(url)
-                        if err != nil {
-                            errorChan <- model.ProgressError{
-                                Job:     "github url",
-                                Message: fmt.Sprintf("error extracting github details from url: %s", err.Error()),
-                            }
-                            <-doneChan
-                            return err
-                        }
-                        report, _, er := RunGithubHistoryHTMLReport(user, repo, filePath, latestFlag, cdnFlag, false, updateChan, errorChan, limitFlag)
+						user, repo, filePath, err := ExtractGithubDetailsFromURL(url)
+						if err != nil {
+							errorChan <- model.ProgressError{
+								Job:     "github url",
+								Message: fmt.Sprintf("error extracting github details from url: %s", err.Error()),
+							}
+							<-doneChan
+							return err
+						}
+						report, _, er := RunGithubHistoryHTMLReport(user, repo, filePath, latestFlag, cdnFlag, false, updateChan, errorChan, limitFlag)
 
-                        // wait for things to be completed.
-                        <-doneChan
+						// wait for things to be completed.
+						<-doneChan
 
-                        if len(report) <= 0 && er != nil {
-                            return er[0]
-                        }
-                        if len(report) > 0 {
-                            err = os.WriteFile("report.html", report, 0664)
-                            if err != nil {
-                                pterm.Error.Println(err.Error())
-                                return err
-                            }
-                            pterm.Success.Printf("%s report written to file 'report.html' (%dkb)", url.String(), len(report)/1024)
-                            pterm.Println()
-                            pterm.Println()
-                        }
-                        return nil
-                    }
+						if len(report) <= 0 && er != nil {
+							return er[0]
+						}
+						if len(report) > 0 {
+							err = os.WriteFile("report.html", report, 0664)
+							if err != nil {
+								pterm.Error.Println(err.Error())
+								return err
+							}
+							pterm.Success.Printf("%s report written to file 'report.html' (%dkb)", url.String(), len(report)/1024)
+							pterm.Println()
+							pterm.Println()
+						}
+						return nil
+					}
 
-                } else {
-                    pterm.Error.Println("Two arguments are required to compare left and right OpenAPI Specifications.")
-                    return nil
-                }
-            }
-            if len(args) == 2 {
+				} else {
+					pterm.Error.Println("Two arguments are required to compare left and right OpenAPI Specifications.")
+					return nil
+				}
+			}
+			if len(args) == 2 {
 
-                // check if the first arg is a directory, if so - process as a git history operation.
-                p := args[0]
-                f, err := os.Stat(p)
-                if err != nil {
-                    pterm.Error.Printf("Cannot open file/repository: '%s'", args[0])
-                    return err
-                }
+				// check if the first arg is a directory, if so - process as a git history operation.
+				p := args[0]
+				f, err := os.Stat(p)
+				if err != nil {
+					pterm.Error.Printf("Cannot open file/repository: '%s'", args[0])
+					return err
+				}
 
-                if f.IsDir() {
-                    repo := p
-                    p = args[1]
-                    f, err = os.Stat(filepath.Join(repo, p))
-                    if err != nil {
-                        pterm.Error.Printf("Cannot open file/repository: '%s'", args[1])
-                        return err
-                    }
-                    go listenForUpdates(updateChan, errorChan)
+				if f.IsDir() {
+					repo := p
+					p = args[1]
+					f, err = os.Stat(filepath.Join(repo, p))
+					if err != nil {
+						pterm.Error.Printf("Cannot open file/repository: '%s'", args[1])
+						return err
+					}
+					go listenForUpdates(updateChan, errorChan)
 
-                    report, _, er := RunGitHistoryHTMLReport(args[0], args[1], latestFlag, cdnFlag, updateChan, errorChan)
-                    <-doneChan
-                    if er != nil {
-                        for x := range er {
-                            pterm.Error.Println(er[x].Error())
-                        }
-                        return er[0]
-                    }
+					report, _, er := RunGitHistoryHTMLReport(args[0], args[1], latestFlag, cdnFlag, updateChan, errorChan)
+					<-doneChan
+					if er != nil {
+						for x := range er {
+							pterm.Error.Println(er[x].Error())
+						}
+						return er[0]
+					}
 
-                    err = os.WriteFile("report.html", report, 0664)
-                    if err != nil {
-                        pterm.Error.Println(err.Error())
-                        return err
-                    }
-                    pterm.Success.Printf("report written to file 'report.html' (%dkb)", len(report)/1024)
-                    pterm.Println()
-                    pterm.Println()
-                    return nil
+					err = os.WriteFile("report.html", report, 0664)
+					if err != nil {
+						pterm.Error.Println(err.Error())
+						return err
+					}
+					pterm.Success.Printf("report written to file 'report.html' (%dkb)", len(report)/1024)
+					pterm.Println()
+					pterm.Println()
+					return nil
 
-                } else {
-                    go listenForUpdates(updateChan, errorChan)
-                    report, errs := RunLeftRightHTMLReport(args[0], args[1], cdnFlag, updateChan, errorChan)
-                    <-doneChan
-                    if len(errs) > 0 {
-                        for e := range errs {
-                            pterm.Error.Println(errs[e].Error())
-                        }
-                        return errors.New("unable to process specifications")
-                    }
+				} else {
+					go listenForUpdates(updateChan, errorChan)
+					report, errs := RunLeftRightHTMLReport(args[0], args[1], cdnFlag, updateChan, errorChan)
+					<-doneChan
+					if len(errs) > 0 {
+						for e := range errs {
+							pterm.Error.Println(errs[e].Error())
+						}
+						return errors.New("unable to process specifications")
+					}
 
-                    err = os.WriteFile("report.html", report, 644)
-                    pterm.Success.Printf("report written to file 'report.html' (%dkb)", len(report)/1024)
-                    pterm.Println()
-                    pterm.Println()
-                    return nil
-                }
-            }
-            pterm.Error.Println("too many arguments, expecting two (2)")
-            return nil
-        },
-    }
-    cmd.Flags().BoolP("no-style", "n", false, "Disable color and style output (very useful for CI/CD)")
-    cmd.Flags().BoolP("use-cdn", "c", false, "Use CDN for CSS and JS delivery instead of bundling inline")
+					err = os.WriteFile("report.html", report, 644)
+					pterm.Success.Printf("report written to file 'report.html' (%dkb)", len(report)/1024)
+					pterm.Println()
+					pterm.Println()
+					return nil
+				}
+			}
+			pterm.Error.Println("too many arguments, expecting two (2)")
+			return nil
+		},
+	}
+	cmd.Flags().BoolP("no-style", "n", false, "Disable color and style output (very useful for CI/CD)")
+	cmd.Flags().BoolP("use-cdn", "c", false, "Use CDN for CSS and JS delivery instead of bundling inline")
 
-    return cmd
+	return cmd
 }
 
 func ExtractGithubDetailsFromURL(url *url.URL) (string, string, string, error) {
-    path := url.Path
-    dir, file := filepath.Split(path)
-    dirSegments := strings.Split(dir, "/")
-    if len(dirSegments) >= 6 {
-        user := dirSegments[1]
-        repo := dirSegments[2]
-        filePath := fmt.Sprintf("%s%s", strings.Join(dirSegments[5:], "/"), file)
-        return user, repo, filePath, nil
-    } else {
-        return "", "", "", fmt.Errorf("url: '%s' not correctly formed", url.String())
-    }
+	path := url.Path
+	dir, file := filepath.Split(path)
+	dirSegments := strings.Split(dir, "/")
+	if len(dirSegments) >= 6 {
+		user := dirSegments[1]
+		repo := dirSegments[2]
+		filePath := fmt.Sprintf("%s%s", strings.Join(dirSegments[5:], "/"), file)
+		return user, repo, filePath, nil
+	} else {
+		return "", "", "", fmt.Errorf("url: '%s' not correctly formed", url.String())
+	}
 }
 
 func RunGitHistoryHTMLReport(gitPath, filePath string, latest, useCDN bool,
-    progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) ([]byte, []*model.Report, []error) {
-    if gitPath == "" || filePath == "" {
-        err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
-        model.SendProgressError("reading paths",
-            err.Error(), errorChan)
-        return nil, nil, []error{err}
-    }
+	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) ([]byte, []*model.Report, []error) {
+	if gitPath == "" || filePath == "" {
+		err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
+		model.SendProgressError("reading paths",
+			err.Error(), errorChan)
+		return nil, nil, []error{err}
+	}
 
-    // build commit history.
-    commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, progressChan, errorChan)
-    if err != nil {
-        return nil, nil, err
-    }
+	// build commit history.
+	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, progressChan, errorChan)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    // populate history with changes and data
-    commitHistory, err = git.PopulateHistoryWithChanges(commitHistory, 0, progressChan, errorChan)
-    if err != nil {
-        return nil, nil, err
-    }
+	// populate history with changes and data
+	commitHistory, err = git.PopulateHistoryWithChanges(commitHistory, 0, progressChan, errorChan)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    if latest {
-        commitHistory = commitHistory[:1]
-    }
+	if latest {
+		commitHistory = commitHistory[:1]
+	}
 
-    var reports []*model.Report
-    for r := range commitHistory {
-        if commitHistory[r].Changes != nil {
-            reports = append(reports, createReport(commitHistory[r]))
-        }
-    }
+	var reports []*model.Report
+	for r := range commitHistory {
+		if commitHistory[r].Changes != nil {
+			reports = append(reports, createReport(commitHistory[r]))
+		}
+	}
 
-    if len(reports) > 0 {
-        model.SendProgressUpdate("extraction",
-            fmt.Sprintf("Extracted '%d' reports from file history", len(reports)), true, progressChan)
-    }
+	if len(reports) > 0 {
+		model.SendProgressUpdate("extraction",
+			fmt.Sprintf("Extracted '%d' reports from file history", len(reports)), true, progressChan)
+	}
 
-    close(progressChan)
+	close(progressChan)
 
-    generator := htmlReport.NewHTMLReport(false, time.Now(), commitHistory)
-    return generator.GenerateReport(false, useCDN, false), reports, nil
+	generator := htmlReport.NewHTMLReport(false, time.Now(), commitHistory)
+	return generator.GenerateReport(false, useCDN, false), reports, nil
 }
 
 func RunGithubHistoryHTMLReport(username, repo, filePath string, latest, useCDN, embeddedMode bool,
-    progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, limit int) ([]byte, []*model.Report, []error) {
+	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, limit int) ([]byte, []*model.Report, []error) {
 
-    commitHistory, errs := git.ProcessGithubRepo(username, repo, filePath, progressChan, errorChan, true, limit)
+	commitHistory, errs := git.ProcessGithubRepo(username, repo, filePath, progressChan, errorChan, true, limit)
 
-    if latest && len(commitHistory) > 1 {
-        commitHistory = commitHistory[:1]
-    }
+	if latest && len(commitHistory) > 1 {
+		commitHistory = commitHistory[:1]
+	}
 
-    var reports []*model.Report
-    for r := range commitHistory {
-        if commitHistory[r].Changes != nil {
-            reports = append(reports, createReport(commitHistory[r]))
-        }
-    }
+	var reports []*model.Report
+	for r := range commitHistory {
+		if commitHistory[r].Changes != nil {
+			reports = append(reports, createReport(commitHistory[r]))
+		}
+	}
 
-    if len(reports) > 0 {
-        model.SendProgressUpdate("extraction",
-            fmt.Sprintf("Extracted '%d' reports from file history", len(reports)), true, progressChan)
-    }
+	if len(reports) > 0 {
+		model.SendProgressUpdate("extraction",
+			fmt.Sprintf("Extracted '%d' reports from file history", len(reports)), true, progressChan)
+	}
 
-    // if there are no reports and no commits, return no bytes.
-    if len(reports) == 0 {
+	// if there are no reports and no commits, return no bytes.
+	if len(reports) == 0 {
 
-        model.SendProgressError("extraction",
-            fmt.Sprintf("history extraction failed %d reports generated for '%s'", len(reports), filePath), errorChan)
+		model.SendProgressError("extraction",
+			fmt.Sprintf("history extraction failed %d reports generated for '%s'", len(reports), filePath), errorChan)
 
-        close(progressChan)
-        return nil, nil, append(errs, fmt.Errorf("no repors extracted, no history found for file '%s'", filePath))
-    }
+		close(progressChan)
+		return nil, nil, append(errs, fmt.Errorf("no repors extracted, no history found for file '%s'", filePath))
+	}
 
-    generator := htmlReport.NewHTMLReport(false, time.Now(), commitHistory)
+	generator := htmlReport.NewHTMLReport(false, time.Now(), commitHistory)
 
-    close(progressChan)
-    return generator.GenerateReport(false, useCDN, embeddedMode), reports, errs
+	close(progressChan)
+	return generator.GenerateReport(false, useCDN, embeddedMode), reports, errs
 }
 
 func RunLeftRightHTMLReport(left, right string, useCDN bool,
-    progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) ([]byte, []error) {
+	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) ([]byte, []error) {
 
-    var leftBytes, rightBytes []byte
-    var errs []error
-    var err error
+	var leftBytes, rightBytes []byte
+	var errs []error
+	var err error
 
-    leftBytes, err = os.ReadFile(left)
-    if err != nil {
-        return nil, []error{err}
-    }
-    rightBytes, err = os.ReadFile(right)
-    if err != nil {
-        return nil, []error{err}
-    }
+	leftBytes, err = os.ReadFile(left)
+	if err != nil {
+		return nil, []error{err}
+	}
+	rightBytes, err = os.ReadFile(right)
+	if err != nil {
+		return nil, []error{err}
+	}
 
-    commits := []*model.Commit{
-        {
-            Hash:       uuid.NewV4().String()[:6],
-            Message:    fmt.Sprintf("New: %s, Original: %s", right, left),
-            CommitDate: time.Now(),
-            Data:       rightBytes,
-        },
-        {
-            Hash:       uuid.NewV4().String()[:6],
-            Message:    fmt.Sprintf("Original file: %s", left),
-            CommitDate: time.Now(),
-            Data:       leftBytes,
-        },
-    }
+	commits := []*model.Commit{
+		{
+			Hash:       uuid.NewV4().String()[:6],
+			Message:    fmt.Sprintf("New: %s, Original: %s", right, left),
+			CommitDate: time.Now(),
+			Data:       rightBytes,
+		},
+		{
+			Hash:       uuid.NewV4().String()[:6],
+			Message:    fmt.Sprintf("Original file: %s", left),
+			CommitDate: time.Now(),
+			Data:       leftBytes,
+		},
+	}
 
-    commits, errs = git.BuildCommitChangelog(commits, progressChan, errorChan)
-    if len(errs) > 0 {
-        close(progressChan)
-        return nil, errs
-    }
-    generator := htmlReport.NewHTMLReport(false, time.Now(), commits)
+	commits, errs = git.BuildCommitChangelog(commits, progressChan, errorChan)
+	if len(errs) > 0 {
+		close(progressChan)
+		return nil, errs
+	}
+	generator := htmlReport.NewHTMLReport(false, time.Now(), commits)
 
-    close(progressChan)
-    return generator.GenerateReport(false, useCDN, false), nil
+	close(progressChan)
+	return generator.GenerateReport(false, useCDN, false), nil
 }
 
 func RunLeftRightHTMLReportViaString(left, right string, useCDN, embedded bool,
-    progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) ([]byte, []error) {
+	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) ([]byte, []error) {
 
-    var errs []error
+	var errs []error
 
-    commits := []*model.Commit{
-        {
-            Hash:       uuid.NewV4().String()[:6],
-            Message:    fmt.Sprintf("Uploaded original (%d bytes)", len(left)),
-            CommitDate: time.Now(),
-            Data:       []byte(left),
-        },
-        {
-            Hash:       uuid.NewV4().String()[:6],
-            Message:    fmt.Sprintf("Uploaded modification (%d bytes)", len(right)),
-            CommitDate: time.Now(),
-            Data:       []byte(right),
-        },
-    }
+	commits := []*model.Commit{
+		{
+			Hash:       uuid.NewV4().String()[:6],
+			Message:    fmt.Sprintf("Uploaded original (%d bytes)", len(left)),
+			CommitDate: time.Now(),
+			Data:       []byte(left),
+		},
+		{
+			Hash:       uuid.NewV4().String()[:6],
+			Message:    fmt.Sprintf("Uploaded modification (%d bytes)", len(right)),
+			CommitDate: time.Now(),
+			Data:       []byte(right),
+		},
+	}
 
-    commits, errs = git.BuildCommitChangelog(commits, progressChan, errorChan)
-    if len(errs) > 0 {
-        close(progressChan)
-        return nil, errs
-    }
-    generator := htmlReport.NewHTMLReport(false, time.Now(), commits)
+	commits, errs = git.BuildCommitChangelog(commits, progressChan, errorChan)
+	if len(errs) > 0 {
+		close(progressChan)
+		return nil, errs
+	}
+	generator := htmlReport.NewHTMLReport(false, time.Now(), commits)
 
-    close(progressChan)
-    return generator.GenerateReport(false, useCDN, embedded), nil
+	close(progressChan)
+	return generator.GenerateReport(false, useCDN, embedded), nil
 }

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -4,306 +4,317 @@
 package cmd
 
 import (
-    "errors"
-    "fmt"
-    "net/url"
-    "os"
-    "path/filepath"
-    "time"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
 
-    "github.com/pb33f/libopenapi/what-changed/reports"
-    "github.com/pb33f/openapi-changes/git"
-    "github.com/pb33f/openapi-changes/model"
-    "github.com/pterm/pterm"
-    "github.com/spf13/cobra"
-    "github.com/twinj/uuid"
+	"github.com/pb33f/libopenapi/what-changed/reports"
+	"github.com/pb33f/openapi-changes/git"
+	"github.com/pb33f/openapi-changes/model"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+	"github.com/twinj/uuid"
 )
 
 func GetSummaryCommand() *cobra.Command {
 
-    cmd := &cobra.Command{
-        SilenceUsage:  true,
-        SilenceErrors: false,
-        Use:           "summary",
-        Short:         "See a summary of changes",
-        Long:          "print a summary of what changed, view a simple tree of changes and summary",
-        Example:       "openapi-changes summary /path/to/git/repo path/to/file/in/repo/openapi.yaml",
-        RunE: func(cmd *cobra.Command, args []string) error {
+	cmd := &cobra.Command{
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		Use:           "summary",
+		Short:         "See a summary of changes",
+		Long:          "print a summary of what changed, view a simple tree of changes and summary",
+		Example:       "openapi-changes summary /path/to/git/repo path/to/file/in/repo/openapi.yaml",
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-            updateChan := make(chan *model.ProgressUpdate)
-            errorChan := make(chan model.ProgressError)
-            doneChan := make(chan bool)
-            failed := false
-            latestFlag, _ := cmd.Flags().GetBool("top")
-            noColorFlag, _ := cmd.Flags().GetBool("no-color")
-            limitFlag, _ := cmd.Flags().GetInt("limit")
+			updateChan := make(chan *model.ProgressUpdate)
+			errorChan := make(chan model.ProgressError)
+			doneChan := make(chan bool)
+			failed := false
+			latestFlag, _ := cmd.Flags().GetBool("top")
+			noColorFlag, _ := cmd.Flags().GetBool("no-color")
+			limitFlag, _ := cmd.Flags().GetInt("limit")
 
-            if noColorFlag {
-                pterm.DisableStyling()
-                pterm.DisableColor()
-            }
+			if noColorFlag {
+				pterm.DisableStyling()
+				pterm.DisableColor()
+			}
 
-            PrintBanner()
+			PrintBanner()
 
-            // if there are no args, print out how to use the console.
-            if len(args) == 0 {
-                PrintHowToUse("summary")
-                return nil
-            }
+			// if there are no args, print out how to use the console.
+			if len(args) == 0 {
+				PrintHowToUse("summary")
+				return nil
+			}
 
-            listenForUpdates := func(updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) {
-                spinner, _ := pterm.DefaultSpinner.Start("starting work.")
-                for {
-                    select {
-                    case update, ok := <-updateChan:
-                        if ok {
-                            spinner.UpdateText(update.Message)
-                            if update.Warning {
-                                pterm.Warning.Println(update.Message)
-                            }
-                        } else {
-                            if !failed {
-                                spinner.Info("printing summary")
-                            } else {
-                                spinner.Fail("failed to complete. sorry!")
-                            }
-                            doneChan <- true
-                            return
-                        }
-                    case err := <-errorChan:
-                        failed = true
-                        spinner.Fail(fmt.Sprintf("Stopped: %s", err.Message))
-                        pterm.Println()
-                        pterm.Println()
-                        doneChan <- true
-                        return
-                    }
-                }
-            }
+			listenForUpdates := func(updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) {
+				var spinner *pterm.SpinnerPrinter
+				if !noColorFlag {
+					spinner, _ = pterm.DefaultSpinner.Start("starting work.")
+				}
+				for {
+					select {
+					case update, ok := <-updateChan:
+						if ok {
+							if !noColorFlag {
+								spinner.UpdateText(update.Message)
+							}
+							if update.Warning {
+								pterm.Warning.Println(update.Message)
+							}
+						} else {
+							if !failed {
+								if !noColorFlag {
+									spinner.Info("printing summary")
+								}
+							} else {
+								if !noColorFlag {
+									spinner.Fail("failed to complete. sorry!")
+								}
+							}
+							doneChan <- true
+							return
+						}
+					case err := <-errorChan:
+						failed = true
+						if !noColorFlag {
+							spinner.Fail(fmt.Sprintf("Stopped: %s", err.Message))
+						}
+						pterm.Println(err)
+						pterm.Println()
+						doneChan <- true
+						return
+					}
+				}
+			}
 
-            // check for two args (left and right)
-            if len(args) < 2 {
+			// check for two args (left and right)
+			if len(args) < 2 {
 
-                // check if arg is an url (like a github url)
-                url, err := url.Parse(args[0])
-                if err == nil {
+				// check if arg is an url (like a github url)
+				url, err := url.Parse(args[0])
+				if err == nil {
 
-                    if url.Host == "github.com" {
-                        go listenForUpdates(updateChan, errorChan)
+					if url.Host == "github.com" {
+						go listenForUpdates(updateChan, errorChan)
 
-                        user, repo, filePath, err := ExtractGithubDetailsFromURL(url)
-                        if err != nil {
-                            errorChan <- model.ProgressError{
-                                Job:     "github url",
-                                Message: fmt.Sprintf("error extracting github details from url: %s", err.Error()),
-                            }
-                            <-doneChan
-                            return err
-                        }
-                        err = runGithubHistorySummary(user, repo, filePath, latestFlag, limitFlag, updateChan, errorChan)
-                        // wait for things to be completed.
-                        <-doneChan
-                        if err != nil {
-                            return err
-                        }
-                        return nil
-                    }
+						user, repo, filePath, err := ExtractGithubDetailsFromURL(url)
+						if err != nil {
+							errorChan <- model.ProgressError{
+								Job:     "github url",
+								Message: fmt.Sprintf("error extracting github details from url: %s", err.Error()),
+							}
+							<-doneChan
+							return err
+						}
+						err = runGithubHistorySummary(user, repo, filePath, latestFlag, limitFlag, updateChan, errorChan)
+						// wait for things to be completed.
+						<-doneChan
+						if err != nil {
+							return err
+						}
+						return nil
+					}
 
-                } else {
-                    pterm.Error.Println("Two arguments are required to compare left and right OpenAPI Specifications.")
-                    return nil
-                }
-            }
-            if len(args) == 2 {
+				} else {
+					pterm.Error.Println("Two arguments are required to compare left and right OpenAPI Specifications.")
+					return nil
+				}
+			}
+			if len(args) == 2 {
 
-                // check if the first arg is a directory, if so - process as a git history operation.
-                p := args[0]
-                f, err := os.Stat(p)
-                if err != nil {
-                    pterm.Error.Printf("Cannot open file/repository: '%s'", args[0])
-                    return err
-                }
+				// check if the first arg is a directory, if so - process as a git history operation.
+				p := args[0]
+				f, err := os.Stat(p)
+				if err != nil {
+					pterm.Error.Printf("Cannot open file/repository: '%s'", args[0])
+					return err
+				}
 
-                if f.IsDir() {
+				if f.IsDir() {
 
-                    repo := p
-                    p = args[1]
-                    f, err = os.Stat(filepath.Join(repo, p))
-                    if err != nil {
-                        pterm.Error.Printf("Cannot open file/repository: '%s'", args[1])
-                        return err
-                    }
+					repo := p
+					p = args[1]
+					f, err = os.Stat(filepath.Join(repo, p))
+					if err != nil {
+						pterm.Error.Printf("Cannot open file/repository: '%s'", args[1])
+						return err
+					}
 
-                    go listenForUpdates(updateChan, errorChan)
+					go listenForUpdates(updateChan, errorChan)
 
-                    err = runGitHistorySummary(args[0], args[1], latestFlag, updateChan, errorChan)
+					err = runGitHistorySummary(args[0], args[1], latestFlag, updateChan, errorChan)
 
-                    <-doneChan
+					<-doneChan
 
-                    if err != nil {
-                        pterm.Error.Println(err.Error())
-                        return err
-                    }
-                } else {
-                    go listenForUpdates(updateChan, errorChan)
-                    errs := runLeftRightSummary(args[0], args[1], updateChan, errorChan)
-                    <-doneChan
-                    if len(errs) > 0 {
-                        for e := range errs {
-                            pterm.Error.Println(errs[e].Error())
-                        }
-                        return errors.New("unable to process specifications")
-                    }
-                    return nil
-                }
-            }
-            pterm.Error.Println("too many arguments, expecting two (2)")
-            return nil
-        },
-    }
-    cmd.Flags().BoolP("no-color", "n", false, "Disable color and style output (very useful for CI/CD)")
-    return cmd
+					if err != nil {
+						pterm.Error.Println(err.Error())
+						return err
+					}
+				} else {
+					go listenForUpdates(updateChan, errorChan)
+					errs := runLeftRightSummary(args[0], args[1], updateChan, errorChan)
+					<-doneChan
+					if len(errs) > 0 {
+						for e := range errs {
+							pterm.Error.Println(errs[e].Error())
+						}
+						return errors.New("unable to process specifications")
+					}
+					return nil
+				}
+			}
+			pterm.Error.Println("too many arguments, expecting two (2)")
+			return nil
+		},
+	}
+	cmd.Flags().BoolP("no-color", "n", false, "Disable color and style output (very useful for CI/CD)")
+	return cmd
 }
 
 func runLeftRightSummary(left, right string, updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) []error {
 
-    var leftBytes, rightBytes []byte
-    var errs []error
-    var err error
+	var leftBytes, rightBytes []byte
+	var errs []error
+	var err error
 
-    leftBytes, err = os.ReadFile(left)
-    if err != nil {
-        return []error{err}
-    }
-    rightBytes, err = os.ReadFile(right)
-    if err != nil {
-        return []error{err}
-    }
+	leftBytes, err = os.ReadFile(left)
+	if err != nil {
+		return []error{err}
+	}
+	rightBytes, err = os.ReadFile(right)
+	if err != nil {
+		return []error{err}
+	}
 
-    commits := []*model.Commit{
-        {
-            Hash:       uuid.NewV4().String()[:6],
-            Message:    fmt.Sprintf("New: %s, Original: %s", right, left),
-            CommitDate: time.Now(),
-            Data:       rightBytes,
-        },
-        {
-            Hash:       uuid.NewV4().String()[:6],
-            Message:    fmt.Sprintf("Original file: %s", left),
-            CommitDate: time.Now(),
-            Data:       leftBytes,
-        },
-    }
+	commits := []*model.Commit{
+		{
+			Hash:       uuid.NewV4().String()[:6],
+			Message:    fmt.Sprintf("New: %s, Original: %s", right, left),
+			CommitDate: time.Now(),
+			Data:       rightBytes,
+		},
+		{
+			Hash:       uuid.NewV4().String()[:6],
+			Message:    fmt.Sprintf("Original file: %s", left),
+			CommitDate: time.Now(),
+			Data:       leftBytes,
+		},
+	}
 
-    commits, errs = git.BuildCommitChangelog(commits, updateChan, errorChan)
-    if len(errs) > 0 {
-        return errs
-    }
-    close(updateChan)
-    close(errorChan)
-    e := printSummaryDetails(commits)
-    if e != nil {
-        return []error{e}
-    }
-    return nil
+	commits, errs = git.BuildCommitChangelog(commits, updateChan, errorChan)
+	if len(errs) > 0 {
+		return errs
+	}
+	close(updateChan)
+	//	close(errorChan)
+	e := printSummaryDetails(commits)
+	if e != nil {
+		return []error{e}
+	}
+	return nil
 }
 
 func runGithubHistorySummary(username, repo, filePath string, latest bool, limit int,
-    progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) error {
-    commitHistory, errs := git.ProcessGithubRepo(username, repo, filePath, progressChan, errorChan, false, limit)
-    if errs != nil {
-        return errs[0]
-    }
-    if latest {
-        commitHistory = commitHistory[:1]
-    }
+	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) error {
+	commitHistory, errs := git.ProcessGithubRepo(username, repo, filePath, progressChan, errorChan, false, limit)
+	if errs != nil {
+		return errs[0]
+	}
+	if latest {
+		commitHistory = commitHistory[:1]
+	}
 
-    model.SendProgressUpdate("extraction",
-        fmt.Sprintf("extracted %d commits from history", len(commitHistory)), true, progressChan)
+	model.SendProgressUpdate("extraction",
+		fmt.Sprintf("extracted %d commits from history", len(commitHistory)), true, progressChan)
 
-    close(progressChan)
+	close(progressChan)
 
-    return printSummaryDetails(commitHistory)
+	return printSummaryDetails(commitHistory)
 }
 
 func runGitHistorySummary(gitPath, filePath string, latest bool,
-    updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) error {
-    if gitPath == "" || filePath == "" {
-        err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
-        model.SendProgressError("git", err.Error(), errorChan)
-        return err
-    }
+	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError) error {
+	if gitPath == "" || filePath == "" {
+		err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
+		model.SendProgressError("git", err.Error(), errorChan)
+		return err
+	}
 
-    model.SendProgressUpdate("extraction",
-        fmt.Sprintf("Extracting history for '%s' in repo '%s",
-            filePath, gitPath), false, updateChan)
+	model.SendProgressUpdate("extraction",
+		fmt.Sprintf("Extracting history for '%s' in repo '%s",
+			filePath, gitPath), false, updateChan)
 
-    // build commit history.
-    commitHistory, errs := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan)
-    if errs != nil {
-        model.SendProgressError("git", fmt.Sprintf("%d errors found extracting history", len(errs)), errorChan)
-        return errs[0]
-    }
+	// build commit history.
+	commitHistory, errs := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan)
+	if errs != nil {
+		model.SendProgressError("git", fmt.Sprintf("%d errors found extracting history", len(errs)), errorChan)
+		return errs[0]
+	}
 
-    // populate history with changes and data
-    git.PopulateHistoryWithChanges(commitHistory, 0, updateChan, errorChan)
+	// populate history with changes and data
+	git.PopulateHistoryWithChanges(commitHistory, 0, updateChan, errorChan)
 
-    if latest {
-        commitHistory = commitHistory[:1]
-    }
-    model.SendProgressUpdate("extraction",
-        fmt.Sprintf("extracted %d commits from history", len(commitHistory)), true, updateChan)
+	if latest {
+		commitHistory = commitHistory[:1]
+	}
+	model.SendProgressUpdate("extraction",
+		fmt.Sprintf("extracted %d commits from history", len(commitHistory)), true, updateChan)
 
-    close(updateChan)
+	close(updateChan)
 
-    return printSummaryDetails(commitHistory)
+	return printSummaryDetails(commitHistory)
 }
 
 func printSummaryDetails(commitHistory []*model.Commit) error {
-    tt := 0
-    tb := 0
-    pterm.Println()
-    errorStyle := pterm.NewStyle(pterm.FgLightRed, pterm.Italic)
-    for c := range commitHistory {
-        tableData := [][]string{{"Document Element", "Total Changes", "Breaking Changes"}}
+	tt := 0
+	tb := 0
+	pterm.Println()
+	errorStyle := pterm.NewStyle(pterm.FgLightRed, pterm.Italic)
+	for c := range commitHistory {
+		tableData := [][]string{{"Document Element", "Total Changes", "Breaking Changes"}}
 
-        if commitHistory[c].Changes != nil {
-            if c == 0 {
-                buildConsoleTree(commitHistory[c].Changes)
-            }
+		if commitHistory[c].Changes != nil {
+			if c == 0 {
+				buildConsoleTree(commitHistory[c].Changes)
+			}
 
-            report := reports.CreateOverallReport(commitHistory[c].Changes)
-            total := 0
-            breaking := 0
-            for l := range report.ChangeReport {
-                total += report.ChangeReport[l].Total
-                tt += total
-                breaking += report.ChangeReport[l].Breaking
-                tb += breaking
-                tableData = append(tableData, []string{
-                    l,
-                    fmt.Sprint(report.ChangeReport[l].Total),
-                    fmt.Sprint(report.ChangeReport[l].Breaking),
-                })
-            }
-            pterm.Printf("Date: %s | Commit: %s\n",
-                commitHistory[c].CommitDate.Format("01/02/06"),
-                commitHistory[c].Message)
-            _ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
-            if breaking == 0 {
-                pterm.Info.Printf("Total Changes: %d\n", total)
-            } else {
-                errorStyle.Printf("❌ %d Breaking changes out of %d\n", breaking, total)
-            }
-            if c < len(commitHistory) {
-                pterm.Println()
-            }
-        }
-    }
+			report := reports.CreateOverallReport(commitHistory[c].Changes)
+			total := 0
+			breaking := 0
+			for l := range report.ChangeReport {
+				total += report.ChangeReport[l].Total
+				tt += total
+				breaking += report.ChangeReport[l].Breaking
+				tb += breaking
+				tableData = append(tableData, []string{
+					l,
+					fmt.Sprint(report.ChangeReport[l].Total),
+					fmt.Sprint(report.ChangeReport[l].Breaking),
+				})
+			}
+			pterm.Printf("Date: %s | Commit: %s\n",
+				commitHistory[c].CommitDate.Format("01/02/06"),
+				commitHistory[c].Message)
+			_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+			if breaking == 0 {
+				pterm.Info.Printf("Total Changes: %d\n", total)
+			} else {
+				errorStyle.Printf("❌ %d Breaking changes out of %d\n", breaking, total)
+			}
+			if c < len(commitHistory) {
+				pterm.Println()
+			}
+		}
+	}
 
-    if tb > 0 {
-        return errors.New("breaking changes discovered")
-    } else {
-        return nil
-    }
+	if tb > 0 {
+		return errors.New("breaking changes discovered")
+	} else {
+		return nil
+	}
 }


### PR DESCRIPTION
`html-report` and `summary` commands were failing with no-color settings, mainly due to pterm getting upset with the spinner when turning off color and styling. So now the spinner is only used when color is not specifically disabled.