### PR TITLE
Fix for #33

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pb33f/openapi-changes
 
-go 1.18
+go 1.20
 
 require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de


### PR DESCRIPTION
The issue was multiple errors being sent down a channel that stops listening after one error, all errors are now packed up and sent using `errors.Join()`