### PR TITLE
New golang images do not build correctly for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.18 as builder
 
 RUN mkdir -p /opt/openapi-changes
 


### PR DESCRIPTION
reverting back to go 1.18, anything above throws an exception, reported in #45 