### PR TITLE
Updating build and npm packaging.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -51,10 +51,10 @@ jobs:
       - name: Check version
         run: echo "Version ${{ github.event.client_payload.new-tag }}"
 
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
 
       - name: Setup Git user

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "npm-install"
   ],
   "dependencies": {
+    "adm-zip": "^0.5.10",
     "node-fetch": "^3.2.10",
     "tar": "^6.1.11"
   },


### PR DESCRIPTION
New windows build means we need to set the binary to be executable after install.