### PR TITLE
changing build to allow chocolatey to fail.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,6 +36,7 @@ jobs:
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
 
   publish_npm:
+    if: success() || failure()
     name: Publish to NPM
     needs: release_and_brew
     runs-on: ubuntu-latest
@@ -75,6 +76,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   push_to_registries:
+    if: success() || failure()
     name: Push Docker image to multiple registries
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
a 403 is being thrown and it’s giving me grief with chocolatey, so npm and docker will stuill work, even after chocolatey is being a pain