### PR TITLE
bumped libopenapi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/gdamore/tcell/v2 v2.6.0
-	github.com/pb33f/libopenapi v0.13.9
+	github.com/pb33f/libopenapi v0.13.10
 	github.com/pterm/pterm v0.12.70
 	github.com/rivo/tview v0.0.0-20231102183219-1b91b8131c43
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pb33f/libopenapi v0.13.9 h1:LQKTjjhYObuw2RUISbzHx+PH6yueht3mNBx3SBVFjOY=
-github.com/pb33f/libopenapi v0.13.9/go.mod h1:Lv2eEtsAtbRFlF8hjH82L8SIGoUNgemMVoKoB6A9THk=
+github.com/pb33f/libopenapi v0.13.10 h1:Njh5yeDKJ38BNAzj56BFiJUA5wR2twhOJRE3g//RJfU=
+github.com/pb33f/libopenapi v0.13.10/go.mod h1:Lv2eEtsAtbRFlF8hjH82L8SIGoUNgemMVoKoB6A9THk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pterm/pterm v0.12.27/go.mod h1:PhQ89w4i95rhgE+xedAoqous6K9X+r6aSOI2eFF7DZI=


### PR DESCRIPTION
a panic was detected online, the culprit was an NPE, it’s now been caught.