### PR TITLE
v0.0.58

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   release_and_brew:
     name: Release and bump homebrew version
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code from repo

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,29 +46,29 @@ brews:
 snapshot:
   name_template: "{{ .Tag }}"
 
-
-chocolateys:
-  - name: openapi-changes
-    owners: Princess Beef Heavy Industries LLC
-    title: openapi-changes - The world's sexiest OpenAPI diffing and breaking change detector tool.
-    authors: Princess Beef Heavy Industries LLC
-    project_url: https://pb33f.io/openapi-changes/
-    url_template: "https://github.com/pb33f/openapi-changes/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    icon_url: 'https://pb33f.io/openapi-changes/openapi-changes-logo.png'
-    copyright: 2023 Princess Beef Heavy Industries LLC
-    license_url: https://github.com/pb33f/openapi-changes/blob/main/LICENSE
-    require_license_acceptance: false
-    project_source_url: https://github.com/pb33f/openapi-changes/
-    docs_url: https://pb33f.io/openapi-changes/
-    bug_tracker_url: https://github.com/pb33f/openapi-changes/issues
-    tags: openapi openapi3 openapi2 swagger openapi-diff openapi-changes openapi-diffing openapi-diff-tool openapi-diff-engine breaking changes
-    summary: openapi-changes is the world's sexiest OpenAPI diffing and breaking change detector tool.
-    description: |
-      openapi-changes will detect all changes (including breaking changes) between two OpenAPI specifications, or 
-      travel back in time through the history of your OpenAPI specification to how it has changed over time. It has
-      the world's sexiest UI for exploring diffs and changes between OpenAPI specifications.
-    release_notes: "https://github.com/pb33f/openapi-changes/releases/tag/v{{ .Version }}"
-    api_key: '{{ .Env.CHOCOLATEY_API_KEY }}'
-    source_repo: "https://push.chocolatey.org/"
-    skip_publish: false
-    goamd64: v1
+# disabled for now, it works but no-one is really using it, and it's screwing up the npm release.
+#chocolateys:
+#  - name: openapi-changes
+#    owners: Princess Beef Heavy Industries LLC
+#    title: openapi-changes - The world's sexiest OpenAPI diffing and breaking change detector tool.
+#    authors: Princess Beef Heavy Industries LLC
+#    project_url: https://pb33f.io/openapi-changes/
+#    url_template: "https://github.com/pb33f/openapi-changes/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+#    icon_url: 'https://pb33f.io/openapi-changes/openapi-changes-logo.png'
+#    copyright: 2023 Princess Beef Heavy Industries LLC
+#    license_url: https://github.com/pb33f/openapi-changes/blob/main/LICENSE
+#    require_license_acceptance: false
+#    project_source_url: https://github.com/pb33f/openapi-changes/
+#    docs_url: https://pb33f.io/openapi-changes/
+#    bug_tracker_url: https://github.com/pb33f/openapi-changes/issues
+#    tags: openapi openapi3 openapi2 swagger openapi-diff openapi-changes openapi-diffing openapi-diff-tool openapi-diff-engine breaking changes
+#    summary: openapi-changes is the world's sexiest OpenAPI diffing and breaking change detector tool.
+#    description: |
+#      openapi-changes will detect all changes (including breaking changes) between two OpenAPI specifications, or
+#      travel back in time through the history of your OpenAPI specification to how it has changed over time. It has
+#      the world's sexiest UI for exploring diffs and changes between OpenAPI specifications.
+#    release_notes: "https://github.com/pb33f/openapi-changes/releases/tag/v{{ .Version }}"
+#    api_key: '{{ .Env.CHOCOLATEY_API_KEY }}'
+#    source_repo: "https://push.chocolatey.org/"
+#    skip_publish: false
+#    goamd64: v1

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -329,6 +329,11 @@ func runLeftRightSummary(left, right string, updateChan chan *model.ProgressUpda
 
 	commits, _ = git.BuildCommitChangelog(commits, updateChan, errorChan, base, remote)
 
+	if len(commits) <= 0 {
+		close(updateChan)
+		return []error{errors.New("cannot compare files, nothing was extracted")}
+	}
+
 	model.SendProgressUpdate("extraction",
 		fmt.Sprintf("extracted %d commits from history", len(commits)), true, updateChan)
 

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -214,7 +214,9 @@ func buildConsoleTree(doc *wcModel.DocumentChanges, markdown bool) {
 		fmt.Println("```")
 	}
 	pterm.DefaultTree.WithRoot(root).Render()
-	fmt.Println("```")
+	if markdown {
+		fmt.Println("```")
+	}
 	fmt.Println()
 
 }


### PR DESCRIPTION
Fixes async deadlock bug when parsing invalid files. 

Removes random markdown output when not using markdown on `summary` command

Disabled choco build, no-one is using it. Moved back to a linux build, which should fix npm on windows (ironic, I know).

