### PR TITLE
v0.0.60 Damn you windows.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,6 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-    format: zip
 checksum:
   name_template: 'checksums.txt'
 

--- a/npm-install/config.js
+++ b/npm-install/config.js
@@ -1,7 +1,7 @@
 export const CONFIG = {
     name: "openapi-changes",
     path: "./bin",
-    url: "https://github.com/pb33f/openapi-changes/releases/download/v{{version}}/{{bin_name}}_{{version}}_{{platform}}_{{arch}}.zip",
+    url: "https://github.com/pb33f/openapi-changes/releases/download/v{{version}}/{{bin_name}}_{{version}}_{{platform}}_{{arch}}.tar.gz",
 };
 export const ARCH_MAPPING = {
     ia32: "i386",


### PR DESCRIPTION
reverted everything back to the olden times, no more direct windows builds, only linux. reverting back to the vacuum design which works consistently for npm.