### PR TITLE
OPENAPI: added commit information to flat report

### DIFF
--- a/cmd/flatten_report.go
+++ b/cmd/flatten_report.go
@@ -18,6 +18,12 @@ func FlattenReport(report *model.Report) *model.FlatReport {
 		changes = append(changes, change)
 	}
 	flatReport.Changes = changes
+
+	// Copy the Commit information from the report to the flatReport and then delete the changes
+	flatReport.Commit = &model.Commit{}
+	*flatReport.Commit = *report.Commit
+	flatReport.Commit.Changes = nil
+
 	return flatReport
 }
 

--- a/model/report.go
+++ b/model/report.go
@@ -20,6 +20,7 @@ type Report struct {
 type FlatReport struct {
 	Summary map[string]*reports.Changed `json:"reportSummary"`
 	Changes []*model.Change             `json:"changes"`
+	Commit  *Commit                     `gorm:"foreignKey:ID" json:"commitDetails"`
 }
 
 type FlatHistoricalReport struct {


### PR DESCRIPTION
The flat report did not have the commit information.

I added code to copy the commit information from the report to the flat report.