### PR TITLE
OPENAPI: added time-limit command and change hashing

### DIFF
--- a/cmd/flatten_report.go
+++ b/cmd/flatten_report.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	whatChanged "github.com/pb33f/libopenapi/what-changed/model"
 	"github.com/pb33f/openapi-changes/model"
 )
 
@@ -12,10 +11,16 @@ func FlattenReport(report *model.Report) *model.FlatReport {
 
 	flatReport := &model.FlatReport{}
 	flatReport.Summary = report.Summary
-	var changes []*whatChanged.Change
+	var changes []*model.HashedChange
 	rpt := report.Commit.Changes
 	for _, change := range rpt.GetAllChanges() {
-		changes = append(changes, change)
+		hashedChange := model.HashedChange{
+			Change: change,
+		}
+
+		hashedChange.HashChange()
+
+		changes = append(changes, &hashedChange)
 	}
 	flatReport.Changes = changes
 
@@ -34,6 +39,7 @@ func FlattenHistoricalReport(report *model.HistoricalReport) *model.FlatHistoric
 	flatReport.GitFilePath = report.GitFilePath
 	flatReport.DateGenerated = report.DateGenerated
 	flatReport.Filename = report.Filename
+	flatReport.Reports = make([]*model.FlatReport, 0)
 	for _, r := range report.Reports {
 		flatReport.Reports = append(flatReport.Reports, FlattenReport(r))
 	}

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -37,6 +37,7 @@ func GetReportCommand() *cobra.Command {
 			failed := false
 			latestFlag, _ := cmd.Flags().GetBool("top")
 			limitFlag, _ := cmd.Flags().GetInt("limit")
+			limitTimeFlag, _ := cmd.Flags().GetInt("limit-time")
 			baseFlag, _ := cmd.Flags().GetString("base")
 			noColorFlag, _ := cmd.Flags().GetBool("no-color")
 			remoteFlag, _ := cmd.Flags().GetBool("remote")
@@ -90,7 +91,7 @@ func GetReportCommand() *cobra.Command {
 							<-doneChan
 							return err
 						}
-						report, er := runGithubHistoryReport(user, repo, filePath, latestFlag, limitFlag, updateChan,
+						report, er := runGithubHistoryReport(user, repo, filePath, latestFlag, limitFlag, limitTimeFlag, updateChan,
 							errorChan, baseFlag, remoteFlag)
 
 						// wait for things to be completed.
@@ -153,7 +154,7 @@ func GetReportCommand() *cobra.Command {
 					go listenForUpdates(updateChan, errorChan)
 
 					report, er := runGitHistoryReport(args[0], args[1], latestFlag, updateChan, errorChan, baseFlag,
-						remoteFlag, limitFlag)
+						remoteFlag, limitFlag, limitTimeFlag)
 
 					<-doneChan
 
@@ -222,7 +223,7 @@ func GetReportCommand() *cobra.Command {
 }
 
 func runGitHistoryReport(gitPath, filePath string, latest bool,
-	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool, limit int) (*model.HistoricalReport, []error) {
+	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool, limit int, limitTime int) (*model.HistoricalReport, []error) {
 
 	if gitPath == "" || filePath == "" {
 		err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
@@ -236,7 +237,7 @@ func runGitHistoryReport(gitPath, filePath string, latest bool,
 			filePath, gitPath), false, updateChan)
 
 	// build commit history.
-	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, limit)
+	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, limit, limitTime)
 	if err != nil {
 		model.SendProgressError("git", fmt.Sprintf("%d errors found building history", len(err)), errorChan)
 		close(updateChan)
@@ -244,7 +245,7 @@ func runGitHistoryReport(gitPath, filePath string, latest bool,
 	}
 
 	// populate history with changes and data
-	commitHistory, err = git.PopulateHistoryWithChanges(commitHistory, 0, updateChan, errorChan, base, remote)
+	commitHistory, err = git.PopulateHistoryWithChanges(commitHistory, 0, limitTime, updateChan, errorChan, base, remote)
 	if err != nil {
 		model.SendProgressError("git", fmt.Sprintf("%d errors found extracting history", len(err)), errorChan)
 		close(updateChan)
@@ -255,7 +256,7 @@ func runGitHistoryReport(gitPath, filePath string, latest bool,
 		commitHistory = commitHistory[:1]
 	}
 
-	var changeReports []*model.Report
+	var changeReports = make([]*model.Report, 0)
 	for r := range commitHistory {
 		if commitHistory[r].Changes != nil {
 			changeReports = append(changeReports, createReport(commitHistory[r]))
@@ -276,11 +277,11 @@ func runGitHistoryReport(gitPath, filePath string, latest bool,
 
 }
 
-func runGithubHistoryReport(username, repo, filePath string, latest bool, limit int,
+func runGithubHistoryReport(username, repo, filePath string, latest bool, limit int, limitTime int,
 	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool) (*model.HistoricalReport, []error) {
 
 	commitHistory, errs := git.ProcessGithubRepo(username, repo, filePath, progressChan, errorChan,
-		false, limit, base, remote)
+		false, limit, limitTime, base, remote)
 	if errs != nil {
 		model.SendProgressError("git", errors.Join(errs...).Error(), errorChan)
 		close(progressChan)
@@ -291,7 +292,7 @@ func runGithubHistoryReport(username, repo, filePath string, latest bool, limit 
 		commitHistory = commitHistory[:1]
 	}
 
-	var ghReports []*model.Report
+	var ghReports = make([]*model.Report, 0)
 	for r := range commitHistory {
 		if commitHistory[r].Changes != nil {
 			ghReports = append(ghReports, createReport(commitHistory[r]))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ func init() {
 	rootCmd.AddCommand(GetHTMLReportCommand())
 	rootCmd.PersistentFlags().BoolP("top", "t", false, "Only show latest changes (last git revision against HEAD)")
 	rootCmd.PersistentFlags().IntP("limit", "l", 5, "Limit history to number of revisions (default is 5)")
+	rootCmd.PersistentFlags().IntP("limit-time", "d", -1, "Limit history to number of days. Supersedes limit argument if present.")
 	rootCmd.PersistentFlags().BoolP("no-logo", "b", false, "Don't print the big purple pb33f banner")
 	rootCmd.PersistentFlags().StringP("base", "p", "", "Base URL or path to use for resolving relative or remote references")
 	rootCmd.PersistentFlags().BoolP("remote", "r", true, "Allow remote reference (URLs and files) to be auto resolved, without a base URL or path (default is on)")

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -43,6 +43,7 @@ func GetSummaryCommand() *cobra.Command {
 			latestFlag, _ := cmd.Flags().GetBool("top")
 			noColorFlag, _ := cmd.Flags().GetBool("no-color")
 			limitFlag, _ := cmd.Flags().GetInt("limit")
+			limitTimeFlag, _ := cmd.Flags().GetInt("limit-time")
 			remoteFlag, _ := cmd.Flags().GetBool("remote")
 			markdownFlag, _ := cmd.Flags().GetBool("markdown")
 
@@ -153,7 +154,7 @@ func GetSummaryCommand() *cobra.Command {
 							return err
 						}
 
-						er := runGithubHistorySummary(user, repo, filePath, latestFlag, limitFlag, updateChan,
+						er := runGithubHistorySummary(user, repo, filePath, latestFlag, limitFlag, limitTimeFlag, updateChan,
 							errorChan, baseFlag, remoteFlag, markdownFlag)
 						// wait for things to be completed.
 						<-doneChan
@@ -206,7 +207,7 @@ func GetSummaryCommand() *cobra.Command {
 					go listenForUpdates(updateChan, errorChan)
 
 					err = runGitHistorySummary(args[0], args[1], latestFlag, updateChan, errorChan,
-						baseFlag, remoteFlag, markdownFlag, limitFlag)
+						baseFlag, remoteFlag, markdownFlag, limitFlag, limitTimeFlag)
 
 					<-doneChan
 
@@ -347,10 +348,10 @@ func runLeftRightSummary(left, right string, updateChan chan *model.ProgressUpda
 	return nil
 }
 
-func runGithubHistorySummary(username, repo, filePath string, latest bool, limit int,
+func runGithubHistorySummary(username, repo, filePath string, latest bool, limit int, limitTime int,
 	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote, markdown bool) error {
 	commitHistory, _ := git.ProcessGithubRepo(username, repo, filePath, progressChan, errorChan,
-		false, limit, base, remote)
+		false, limit, limitTime, base, remote)
 
 	if latest {
 		commitHistory = commitHistory[:1]
@@ -365,7 +366,7 @@ func runGithubHistorySummary(username, repo, filePath string, latest bool, limit
 }
 
 func runGitHistorySummary(gitPath, filePath string, latest bool,
-	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote, markdown bool, limit int) error {
+	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote, markdown bool, limit int, limitTime int) error {
 	if gitPath == "" || filePath == "" {
 		err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
 		model.SendProgressError("git", err.Error(), errorChan)
@@ -377,7 +378,7 @@ func runGitHistorySummary(gitPath, filePath string, latest bool,
 			filePath, gitPath), false, updateChan)
 
 	// build commit history.
-	commitHistory, errs := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, limit)
+	commitHistory, errs := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, limit, limitTime)
 	if errs != nil {
 		model.SendProgressError("git", fmt.Sprintf("%d errors found extracting history", len(errs)), errorChan)
 		close(updateChan)
@@ -385,7 +386,7 @@ func runGitHistorySummary(gitPath, filePath string, latest bool,
 	}
 
 	// populate history with changes and data
-	git.PopulateHistoryWithChanges(commitHistory, 0, updateChan, errorChan, base, remote)
+	git.PopulateHistoryWithChanges(commitHistory, 0, limitTime, updateChan, errorChan, base, remote)
 
 	if latest {
 		commitHistory = commitHistory[:1]

--- a/git/read_local_test.go
+++ b/git/read_local_test.go
@@ -38,7 +38,7 @@ func TestExtractHistoryFromFile(t *testing.T) {
 
 	// this shit times out in the pipeline (damn you github runners)
 	ctx, cncl := context.WithTimeout(context.Background(), 5*time.Second)
-	history, _ := ExtractHistoryFromFile("./", "read_local.go", c, e, 25)
+	history, _ := ExtractHistoryFromFile("./", "read_local.go", c, e, 25, -1)
 	defer cncl()
 
 	select {
@@ -67,7 +67,7 @@ func TestExtractHistoryFromFile_Fail(t *testing.T) {
 		}
 	}()
 
-	history, _ := ExtractHistoryFromFile("./", "no_file_nope", c, e, 5)
+	history, _ := ExtractHistoryFromFile("./", "no_file_nope", c, e, 5, -1)
 	<-d
 	assert.Len(t, history, 0)
 }

--- a/model/report.go
+++ b/model/report.go
@@ -4,10 +4,51 @@
 package model
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"github.com/pb33f/libopenapi/what-changed/model"
 	"github.com/pb33f/libopenapi/what-changed/reports"
 	"time"
 )
+
+type HashedChange struct {
+	*model.Change
+	ChangeHash string `json:"changeHash,omitempty"`
+}
+
+func (hc *HashedChange) MarshalJSON() ([]byte, error) {
+	changeJson, err := hc.Change.MarshalJSON()
+
+	if err != nil {
+		return nil, err
+	}
+
+	var data map[string]interface{}
+
+	err = json.Unmarshal(changeJson, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	data["changeHash"] = hc.ChangeHash
+
+	return json.Marshal(data)
+}
+
+func (hc *HashedChange) HashChange() {
+
+	context := hc.Context
+	contextString := fmt.Sprintf("%d-%d-%d-%d", context.OriginalLine, context.OriginalColumn, context.NewLine, context.NewColumn)
+
+	changeString := fmt.Sprintf("%d-%s-%s-%s-%s", hc.ChangeType, hc.Property, hc.Original, hc.New, contextString)
+
+	hasher := sha256.New()
+	hasher.Write([]byte(changeString))
+
+	hc.ChangeHash = base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+}
 
 type Report struct {
 	ID        uint                        `gorm:"primaryKey" json:"-"`
@@ -19,7 +60,7 @@ type Report struct {
 
 type FlatReport struct {
 	Summary map[string]*reports.Changed `json:"reportSummary"`
-	Changes []*model.Change             `json:"changes"`
+	Changes []*HashedChange             `json:"changes"`
 	Commit  *Commit                     `gorm:"foreignKey:ID" json:"commitDetails"`
 }
 


### PR DESCRIPTION
This MR adds the `time-limit` option to restrict the number of changes by the number of days in the past.

Additionally, it adds a sha256 hash of each change in order to allow deduplication.