### PR TITLE
Add global-revisions flag

### DIFF
--- a/cmd/console.go
+++ b/cmd/console.go
@@ -37,6 +37,7 @@ func GetConsoleCommand() *cobra.Command {
 			doneChan := make(chan bool)
 			failed := false
 			latestFlag, _ := cmd.Flags().GetBool("top")
+			repoRevisionsFlag, _ := cmd.Flags().GetBool("repo-revisions")
 			limitFlag, _ := cmd.Flags().GetInt("limit")
 			limitTimeFlag, _ := cmd.Flags().GetInt("limit-time")
 			baseFlag, _ := cmd.Flags().GetString("base")
@@ -205,7 +206,7 @@ func GetConsoleCommand() *cobra.Command {
 
 					go listenForUpdates(updateChan, errorChan)
 
-					commits, errs := runGitHistoryConsole(args[0], args[1], latestFlag, limitFlag, limitTimeFlag,
+					commits, errs := runGitHistoryConsole(args[0], args[1], latestFlag, repoRevisionsFlag, limitFlag, limitTimeFlag,
 						updateChan, errorChan, baseFlag, remoteFlag)
 
 					// wait.
@@ -301,7 +302,7 @@ func runGithubHistoryConsole(username, repo, filePath string, latest bool, limit
 	return commitHistory, nil
 }
 
-func runGitHistoryConsole(gitPath, filePath string, latest bool, limit int, limitTime int,
+func runGitHistoryConsole(gitPath, filePath string, latest bool, repoRevisions bool, limit int, limitTime int,
 	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool) ([]*model.Commit, []error) {
 
 	if gitPath == "" || filePath == "" {
@@ -315,7 +316,7 @@ func runGitHistoryConsole(gitPath, filePath string, latest bool, limit int, limi
 			filePath, gitPath), false, updateChan)
 
 	// build commit history.
-	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, limit, limitTime)
+	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, repoRevisions, limit, limitTime)
 
 	if err != nil {
 		close(updateChan)

--- a/cmd/console.go
+++ b/cmd/console.go
@@ -37,7 +37,7 @@ func GetConsoleCommand() *cobra.Command {
 			doneChan := make(chan bool)
 			failed := false
 			latestFlag, _ := cmd.Flags().GetBool("top")
-			repoRevisionsFlag, _ := cmd.Flags().GetBool("repo-revisions")
+			globalRevisionsFlag, _ := cmd.Flags().GetBool("global-revisions")
 			limitFlag, _ := cmd.Flags().GetInt("limit")
 			limitTimeFlag, _ := cmd.Flags().GetInt("limit-time")
 			baseFlag, _ := cmd.Flags().GetString("base")
@@ -206,7 +206,7 @@ func GetConsoleCommand() *cobra.Command {
 
 					go listenForUpdates(updateChan, errorChan)
 
-					commits, errs := runGitHistoryConsole(args[0], args[1], latestFlag, repoRevisionsFlag, limitFlag, limitTimeFlag,
+					commits, errs := runGitHistoryConsole(args[0], args[1], latestFlag, globalRevisionsFlag, limitFlag, limitTimeFlag,
 						updateChan, errorChan, baseFlag, remoteFlag)
 
 					// wait.
@@ -302,7 +302,7 @@ func runGithubHistoryConsole(username, repo, filePath string, latest bool, limit
 	return commitHistory, nil
 }
 
-func runGitHistoryConsole(gitPath, filePath string, latest bool, repoRevisions bool, limit int, limitTime int,
+func runGitHistoryConsole(gitPath, filePath string, latest bool, globalRevisions bool, limit int, limitTime int,
 	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool) ([]*model.Commit, []error) {
 
 	if gitPath == "" || filePath == "" {
@@ -316,7 +316,7 @@ func runGitHistoryConsole(gitPath, filePath string, latest bool, repoRevisions b
 			filePath, gitPath), false, updateChan)
 
 	// build commit history.
-	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, repoRevisions, limit, limitTime)
+	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, globalRevisions, limit, limitTime)
 
 	if err != nil {
 		close(updateChan)

--- a/cmd/html_report.go
+++ b/cmd/html_report.go
@@ -42,7 +42,7 @@ func GetHTMLReportCommand() *cobra.Command {
 			noColorFlag, _ := cmd.Flags().GetBool("no-color")
 			cdnFlag, _ := cmd.Flags().GetBool("use-cdn")
 			latestFlag, _ := cmd.Flags().GetBool("top")
-			repoRevisionsFlag, _ := cmd.Flags().GetBool("repo-revisions")
+			globalRevisionsFlag, _ := cmd.Flags().GetBool("global-revisions")
 			limitFlag, _ := cmd.Flags().GetInt("limit")
 			limitTimeFlag, _ := cmd.Flags().GetInt("limit-time")
 			remoteFlag, _ := cmd.Flags().GetBool("remote")
@@ -228,7 +228,7 @@ func GetHTMLReportCommand() *cobra.Command {
 					go listenForUpdates(updateChan, errorChan)
 
 					report, _, er := RunGitHistoryHTMLReport(args[0], args[1], latestFlag, cdnFlag,
-						updateChan, errorChan, baseFlag, remoteFlag, repoRevisionsFlag, limitFlag, limitTimeFlag)
+						updateChan, errorChan, baseFlag, remoteFlag, globalRevisionsFlag, limitFlag, limitTimeFlag)
 					<-doneChan
 					if er != nil {
 						for x := range er {
@@ -305,7 +305,7 @@ func ExtractGithubDetailsFromURL(url *url.URL) (string, string, string, error) {
 }
 
 func RunGitHistoryHTMLReport(gitPath, filePath string, latest, useCDN bool,
-	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool, repoRevisions bool, limit int, limitTime int) ([]byte, []*model.Report, []error) {
+	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool, globalRevisions bool, limit int, limitTime int) ([]byte, []*model.Report, []error) {
 	if gitPath == "" || filePath == "" {
 		err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
 		model.SendProgressError("reading paths",
@@ -315,7 +315,7 @@ func RunGitHistoryHTMLReport(gitPath, filePath string, latest, useCDN bool,
 	}
 
 	// build commit history.
-	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, progressChan, errorChan, repoRevisions, limit, limitTime)
+	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, progressChan, errorChan, globalRevisions, limit, limitTime)
 	if err != nil {
 		model.SendFatalError("extraction",
 			fmt.Sprintf("cannot extract history %s", errors.Join(err...)), errorChan)

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -36,7 +36,7 @@ func GetReportCommand() *cobra.Command {
 			doneChan := make(chan bool)
 			failed := false
 			latestFlag, _ := cmd.Flags().GetBool("top")
-			repoRevisionsFlag, _ := cmd.Flags().GetBool("repo-revisions")
+			globalRevisionsFlag, _ := cmd.Flags().GetBool("global-revisions")
 			limitFlag, _ := cmd.Flags().GetInt("limit")
 			limitTimeFlag, _ := cmd.Flags().GetInt("limit-time")
 			baseFlag, _ := cmd.Flags().GetString("base")
@@ -155,7 +155,7 @@ func GetReportCommand() *cobra.Command {
 					go listenForUpdates(updateChan, errorChan)
 
 					report, er := runGitHistoryReport(args[0], args[1], latestFlag, updateChan, errorChan, baseFlag,
-						remoteFlag, repoRevisionsFlag, limitFlag, limitTimeFlag)
+						remoteFlag, globalRevisionsFlag, limitFlag, limitTimeFlag)
 
 					<-doneChan
 
@@ -226,7 +226,7 @@ func GetReportCommand() *cobra.Command {
 }
 
 func runGitHistoryReport(gitPath, filePath string, latest bool,
-	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool, repoRevisions bool, limit int, limitTime int) (*model.HistoricalReport, []error) {
+	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool, globalRevisions bool, limit int, limitTime int) (*model.HistoricalReport, []error) {
 
 	if gitPath == "" || filePath == "" {
 		err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
@@ -240,7 +240,7 @@ func runGitHistoryReport(gitPath, filePath string, latest bool,
 			filePath, gitPath), false, updateChan)
 
 	// build commit history.
-	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, repoRevisions, limit, limitTime)
+	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, globalRevisions, limit, limitTime)
 	if err != nil {
 		model.SendProgressError("git", fmt.Sprintf("%d errors found building history", len(err)), errorChan)
 		close(updateChan)

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -36,6 +36,7 @@ func GetReportCommand() *cobra.Command {
 			doneChan := make(chan bool)
 			failed := false
 			latestFlag, _ := cmd.Flags().GetBool("top")
+			repoRevisionsFlag, _ := cmd.Flags().GetBool("repo-revisions")
 			limitFlag, _ := cmd.Flags().GetInt("limit")
 			limitTimeFlag, _ := cmd.Flags().GetInt("limit-time")
 			baseFlag, _ := cmd.Flags().GetString("base")
@@ -154,7 +155,7 @@ func GetReportCommand() *cobra.Command {
 					go listenForUpdates(updateChan, errorChan)
 
 					report, er := runGitHistoryReport(args[0], args[1], latestFlag, updateChan, errorChan, baseFlag,
-						remoteFlag, limitFlag, limitTimeFlag)
+						remoteFlag, repoRevisionsFlag, limitFlag, limitTimeFlag)
 
 					<-doneChan
 
@@ -225,7 +226,7 @@ func GetReportCommand() *cobra.Command {
 }
 
 func runGitHistoryReport(gitPath, filePath string, latest bool,
-	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool, limit int, limitTime int) (*model.HistoricalReport, []error) {
+	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote bool, repoRevisions bool, limit int, limitTime int) (*model.HistoricalReport, []error) {
 
 	if gitPath == "" || filePath == "" {
 		err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
@@ -239,7 +240,7 @@ func runGitHistoryReport(gitPath, filePath string, latest bool,
 			filePath, gitPath), false, updateChan)
 
 	// build commit history.
-	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, limit, limitTime)
+	commitHistory, err := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, repoRevisions, limit, limitTime)
 	if err != nil {
 		model.SendProgressError("git", fmt.Sprintf("%d errors found building history", len(err)), errorChan)
 		close(updateChan)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var (
@@ -61,6 +62,7 @@ func init() {
 	rootCmd.AddCommand(GetHTMLReportCommand())
 	rootCmd.PersistentFlags().BoolP("top", "t", false, "Only show latest changes (last git revision against HEAD)")
 	rootCmd.PersistentFlags().IntP("limit", "l", 5, "Limit history to number of revisions (default is 5)")
+	rootCmd.PersistentFlags().BoolP("repo-revisions", "R", false, "Consider all revisions in limit, not just the ones for the file")
 	rootCmd.PersistentFlags().IntP("limit-time", "d", -1, "Limit history to number of days. Supersedes limit argument if present.")
 	rootCmd.PersistentFlags().BoolP("no-logo", "b", false, "Don't print the big purple pb33f banner")
 	rootCmd.PersistentFlags().StringP("base", "p", "", "Base URL or path to use for resolving relative or remote references")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,7 +62,7 @@ func init() {
 	rootCmd.AddCommand(GetHTMLReportCommand())
 	rootCmd.PersistentFlags().BoolP("top", "t", false, "Only show latest changes (last git revision against HEAD)")
 	rootCmd.PersistentFlags().IntP("limit", "l", 5, "Limit history to number of revisions (default is 5)")
-	rootCmd.PersistentFlags().BoolP("repo-revisions", "R", false, "Consider all revisions in limit, not just the ones for the file")
+	rootCmd.PersistentFlags().BoolP("global-revisions", "R", false, "Consider all revisions in limit, not just the ones for the file")
 	rootCmd.PersistentFlags().IntP("limit-time", "d", -1, "Limit history to number of days. Supersedes limit argument if present.")
 	rootCmd.PersistentFlags().BoolP("no-logo", "b", false, "Don't print the big purple pb33f banner")
 	rootCmd.PersistentFlags().StringP("base", "p", "", "Base URL or path to use for resolving relative or remote references")

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -43,7 +43,7 @@ func GetSummaryCommand() *cobra.Command {
 			baseFlag, _ := cmd.Flags().GetString("base")
 			latestFlag, _ := cmd.Flags().GetBool("top")
 			noColorFlag, _ := cmd.Flags().GetBool("no-color")
-			repoRevisionsFlag, _ := cmd.Flags().GetBool("repo-revisions")
+			globalRevisionsFlag, _ := cmd.Flags().GetBool("global-revisions")
 			limitFlag, _ := cmd.Flags().GetInt("limit")
 			limitTimeFlag, _ := cmd.Flags().GetInt("limit-time")
 			remoteFlag, _ := cmd.Flags().GetBool("remote")
@@ -228,7 +228,7 @@ func GetSummaryCommand() *cobra.Command {
 					go listenForUpdates(updateChan, errorChan)
 
 					err = runGitHistorySummary(args[0], args[1], latestFlag, updateChan, errorChan,
-						baseFlag, remoteFlag, markdownFlag, repoRevisionsFlag, limitFlag, limitTimeFlag)
+						baseFlag, remoteFlag, markdownFlag, globalRevisionsFlag, limitFlag, limitTimeFlag)
 
 					<-doneChan
 
@@ -392,7 +392,7 @@ func runGithubHistorySummary(username, repo, filePath string, latest bool, limit
 }
 
 func runGitHistorySummary(gitPath, filePath string, latest bool,
-	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote, markdown bool, repoRevisions bool, limit int, limitTime int) error {
+	updateChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, base string, remote, markdown bool, globalRevisions bool, limit int, limitTime int) error {
 	if gitPath == "" || filePath == "" {
 		err := errors.New("please supply a path to a git repo via -r, and a path to a file via -f")
 		model.SendProgressError("git", err.Error(), errorChan)
@@ -404,7 +404,7 @@ func runGitHistorySummary(gitPath, filePath string, latest bool,
 			filePath, gitPath), false, updateChan)
 
 	// build commit history.
-	commitHistory, errs := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, repoRevisions, limit, limitTime)
+	commitHistory, errs := git.ExtractHistoryFromFile(gitPath, filePath, updateChan, errorChan, globalRevisions, limit, limitTime)
 	if errs != nil {
 		model.SendProgressError("git", fmt.Sprintf("%d errors found extracting history", len(errs)), errorChan)
 		close(updateChan)

--- a/git/read_local.go
+++ b/git/read_local.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,6 +31,7 @@ const (
 	TOPLEVEL  = "--show-toplevel"
 	NOPAGER   = "--no-pager"
 	LOGFORMAT = "--pretty=%cD||%h||%s||%an||%ae"
+	NUMBER    = "-n"
 	DIV       = "--"
 )
 
@@ -60,7 +62,17 @@ func GetTopLevel(dir string) (string, error) {
 func ExtractHistoryFromFile(repoDirectory, filePath string,
 	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, repoRevisions bool, limit int, limitTime int) ([]*model.Commit, []error) {
 
-	cmd := exec.Command(GIT, NOPAGER, LOG, LOGFORMAT, DIV, filePath)
+	args := []string{NOPAGER, LOG, LOGFORMAT}
+
+	if limit > 0 && repoRevisions {
+		args = append(args, fmt.Sprintf("HEAD~%d..HEAD", limit))
+	} else if limit > 0 {
+		args = append(args, NUMBER, strconv.Itoa(limit))
+	}
+
+	args = append(args, DIV, filePath)
+
+	cmd := exec.Command(GIT, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/git/read_local.go
+++ b/git/read_local.go
@@ -60,11 +60,11 @@ func GetTopLevel(dir string) (string, error) {
 }
 
 func ExtractHistoryFromFile(repoDirectory, filePath string,
-	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, repoRevisions bool, limit int, limitTime int) ([]*model.Commit, []error) {
+	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, globalRevisions bool, limit int, limitTime int) ([]*model.Commit, []error) {
 
 	args := []string{NOPAGER, LOG, LOGFORMAT}
 
-	if limit > 0 && repoRevisions {
+	if limit > 0 && globalRevisions {
 		args = append(args, fmt.Sprintf("HEAD~%d..HEAD", limit))
 	} else if limit > 0 {
 		args = append(args, NUMBER, strconv.Itoa(limit))

--- a/git/read_local.go
+++ b/git/read_local.go
@@ -7,11 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/araddon/dateparse"
-	"github.com/pb33f/libopenapi"
-	"github.com/pb33f/libopenapi/datamodel"
-	"github.com/pb33f/openapi-changes/model"
-	"github.com/pterm/pterm"
 	"log/slog"
 	"net/url"
 	"os"
@@ -19,6 +14,12 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/araddon/dateparse"
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel"
+	"github.com/pb33f/openapi-changes/model"
+	"github.com/pterm/pterm"
 )
 
 const (
@@ -57,7 +58,7 @@ func GetTopLevel(dir string) (string, error) {
 }
 
 func ExtractHistoryFromFile(repoDirectory, filePath string,
-	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, limit int, limitTime int) ([]*model.Commit, []error) {
+	progressChan chan *model.ProgressUpdate, errorChan chan model.ProgressError, repoRevisions bool, limit int, limitTime int) ([]*model.Commit, []error) {
 
 	cmd := exec.Command(GIT, NOPAGER, LOG, LOGFORMAT, DIV, filePath)
 	var stdout, stderr bytes.Buffer

--- a/git/read_local_test.go
+++ b/git/read_local_test.go
@@ -5,10 +5,11 @@ package git
 
 import (
 	"context"
-	"github.com/pb33f/openapi-changes/model"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/pb33f/openapi-changes/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckLocalRepoAvailable(t *testing.T) {
@@ -38,7 +39,7 @@ func TestExtractHistoryFromFile(t *testing.T) {
 
 	// this shit times out in the pipeline (damn you github runners)
 	ctx, cncl := context.WithTimeout(context.Background(), 5*time.Second)
-	history, _ := ExtractHistoryFromFile("./", "read_local.go", c, e, 25, -1)
+	history, _ := ExtractHistoryFromFile("./", "read_local.go", c, e, false, 25, -1)
 	defer cncl()
 
 	select {
@@ -67,7 +68,7 @@ func TestExtractHistoryFromFile_Fail(t *testing.T) {
 		}
 	}()
 
-	history, _ := ExtractHistoryFromFile("./", "no_file_nope", c, e, 5, -1)
+	history, _ := ExtractHistoryFromFile("./", "no_file_nope", c, e, false, 5, -1)
 	<-d
 	assert.Len(t, history, 0)
 }


### PR DESCRIPTION
I'm trying to include openapi-changes in our GitHub Actions CI to detect breaking changes in pull requests. My approach to doing this was to take the number of commits made on a branch `n` (given by `github.event.pull_request.commits`) and passing `n+1` to `openapi-changes` via the `--limit` flag.

**Problem**
What I found was that the tool looks at the full local git history of the file, and uses the `--limit` flag to cut off after `n` commits. This leads to problems when a PR has `10` commits, but none or only some changed the OpenAPI spec being checked.

**Approach**
As a quick fix, this PR adds a `global-revisions` boolean flag, which is used to instruct `git` to list the history between specific revisions (i.e., `HEAD~(n+1)..HEAD`).

**Alternative Approaches**
I've seen #85 and I think the approach of passing `git` revisions directly makes a lot of sense. However, I think there's some ambiguity around how this should be implemented.

- One could pass two revisions and do a left-right comparison.
- One could pass two revisions and do a report for every commit between them, as is the current behavior.
- One could take a full revisions argument string that matches the supported inputs of `git log` itself.

All these are worth exploring, but I needed a quick win.