### PR TITLE
feat: support base commit-based checks

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,7 @@ func init() {
 	rootCmd.PersistentFlags().IntP("limit-time", "d", -1, "Limit history to number of days. Supersedes limit argument if present.")
 	rootCmd.PersistentFlags().BoolP("no-logo", "b", false, "Don't print the big purple pb33f banner")
 	rootCmd.PersistentFlags().StringP("base", "p", "", "Base URL or path to use for resolving relative or remote references")
+	rootCmd.PersistentFlags().StringP("base-commit", "", "", "Base commit to compare against (will check until commit is found or limit is reached -- make sure to not shallow clone)")
 	rootCmd.PersistentFlags().BoolP("remote", "r", true, "Allow remote reference (URLs and files) to be auto resolved, without a base URL or path (default is on)")
 	rootCmd.PersistentFlags().BoolP("ext-refs", "", false, "Turn on $ref lookups and resolving for extensions (x-) objects")
 }

--- a/git/read_local_test.go
+++ b/git/read_local_test.go
@@ -39,7 +39,7 @@ func TestExtractHistoryFromFile(t *testing.T) {
 
 	// this shit times out in the pipeline (damn you github runners)
 	ctx, cncl := context.WithTimeout(context.Background(), 5*time.Second)
-	history, _ := ExtractHistoryFromFile("./", "read_local.go", c, e, false, 25, -1)
+	history, _ := ExtractHistoryFromFile("./", "read_local.go", "", c, e, false, 25, -1)
 	defer cncl()
 
 	select {
@@ -68,7 +68,7 @@ func TestExtractHistoryFromFile_Fail(t *testing.T) {
 		}
 	}()
 
-	history, _ := ExtractHistoryFromFile("./", "no_file_nope", c, e, false, 5, -1)
+	history, _ := ExtractHistoryFromFile("./", "no_file_nope", "", c, e, false, 5, -1)
 	<-d
 	assert.Len(t, history, 0)
 }


### PR DESCRIPTION
## Changes in this commit

Adds a `--base-commit` flag, which is used as the oldest commit to compare against. This is particularly useful in a PR situation, where you want to compare against changes that occurred in the PR only.

Note that it doesn't check the differences inside of the base commit, rather, the base commit is considered the "start" of the history.

Examples:

```console
$ openapi-changes summary \
	--limit 100 \
	--base-commit '89e8d64ac465dfd4cd11c20606df54a40943cca0' \
	./ sample-specs/petstorev3.json

$ openapi-changes summary \
	--limit 100 \
	--base-commit '89e8d64ac465dfd4cd11c20606df54a40943cca0' \
	'https://github.com/pb33f/openapi-changes/commits/main/sample-specs/petstorev3.json'
```

This is a simpler implementation of something like what golangci-lint does, with `--new-from-rev`. With the Git-directory based approach, you could probably also use the ref name, not just the commit.

## Reviewer Notes

- Almost all error reporting is currently broken, at least with `openapi-changes summary`
  - Errors from github checks aren't even returned, and it just hangs forever (unrelated to my changes)
  - Git related changes, though it attempts to send an "error update", still also hang forever (unrelated to my changes).
  - This might occur for commands other than `summary` too, I just noticed it with `summary`.
  - Looks like it's related to this line:
    - https://github.com/pb33f/openapi-changes/blob/2e429fe380218111f284f623e5ba12857c66ead9/cmd/summary.go#L95
    - Because `, ok` is used, all other selects in that block will never be checked.
    - I'd try and fix, but this code is kind of a mess.
- There are a lot of errors that are not checked correctly, an insane amount of code duplication, functions with too many arguments, etc. Was really hard to keep track of the changes, and feel like there needs to be a large refactoring to clean things up.