### PR TITLE
chore: remove node fetch

### DIFF
--- a/npm-install/postinstall.js
+++ b/npm-install/postinstall.js
@@ -1,6 +1,5 @@
 import { createWriteStream } from "fs";
 import * as fs from "fs/promises";
-import fetch from "node-fetch";
 import { pipeline } from "stream/promises";
 import tar from "tar";
 import { execSync } from "child_process";

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/pb33f/openapi-changes.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "postinstall": "node ./npm-install/postinstall.js"
@@ -24,7 +24,6 @@
   ],
   "dependencies": {
     "adm-zip": "^0.5.10",
-    "node-fetch": "^3.2.10",
     "tar": "^6.1.11"
   },
   "bugs": {


### PR DESCRIPTION
If you're okay with bumping the minimum Node version, you can drop the `node-fetch` dependency which is **17MB** unpacked on disk. That's a huge difference.

<img width="1363" height="795" alt="image" src="https://github.com/user-attachments/assets/c3b025a6-4e82-40fb-8f64-c25f795e12d0" />

Reference: https://npmgraph.js.org/?q=%40pb33f%2Fopenapi-changes