### PR TITLE
Fixed the conflict with the use-cdn and config flags.

### DIFF
--- a/cmd/html_report.go
+++ b/cmd/html_report.go
@@ -279,7 +279,7 @@ func GetHTMLReportCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolP("no-color", "n", false, "Disable color and style output (very useful for CI/CD)")
-	cmd.Flags().BoolP("use-cdn", "c", false, "Use CDN for CSS and JS delivery instead of bundling inline")
+	cmd.Flags().Bool("use-cdn", false, "Use CDN for CSS and JS delivery instead of bundling inline")
 	cmd.Flags().StringP("report-file", "", "report.html", "The name of the HTML report file (defaults to 'report.html')")
 
 	return cmd

--- a/cmd/markdown_report.go
+++ b/cmd/markdown_report.go
@@ -279,7 +279,7 @@ func GetMarkdownReportCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolP("no-color", "n", false, "Disable color and style output (very useful for CI/CD)")
-	cmd.Flags().BoolP("use-cdn", "c", false, "Use CDN for CSS and JS delivery instead of bundling inline")
+	cmd.Flags().Bool("use-cdn", false, "Use CDN for CSS and JS delivery instead of bundling inline")
 	cmd.Flags().StringP("report-file", "", "report.md", "The name of the Markdown report file (defaults to 'report.md')")
 
 	return cmd


### PR DESCRIPTION
Fix the shorthand config problem that we have conflicting with the markdown and the HTML report.

panic in html-report and markdown-reporting, flag conflict has been resolved, 